### PR TITLE
Add hero banner with transitions and responsive updates

### DIFF
--- a/cisadex/index.html
+++ b/cisadex/index.html
@@ -16,6 +16,21 @@
     <input id="search" type="search" placeholder="Search CISA (programs, sectors, SCC/GCC, JCDC, docs)..." aria-label="Search" />
   </header>
 
+  <section class="hero">
+    <a href="https://www.cisa.gov/report" class="card">
+      <div class="card-title">Report a Cyber Incident</div>
+      <div class="card-meta">24/7 portal for suspected intrusions or ransomware incidents.</div>
+    </a>
+    <a href="https://www.cisa.gov/cyber-hygiene-services" class="card">
+      <div class="card-title">Cyber Hygiene Services</div>
+      <div class="card-meta">Free vulnerability scanning and mitigation resources.</div>
+    </a>
+    <a href="https://www.cisa.gov/training-exercises" class="card">
+      <div class="card-title">Training & Exercises</div>
+      <div class="card-meta">Courses and exercises to build cybersecurity skills.</div>
+    </a>
+  </section>
+
   <nav class="tabs" role="tablist" aria-label="Primary">
     <button class="tab active" data-panel="respond">Respond</button>
     <button class="tab" data-panel="prepare">Prepare</button>

--- a/cisadex/style.css
+++ b/cisadex/style.css
@@ -57,8 +57,16 @@ h1{font-size:1.2rem; margin:0; letter-spacing:.3px}
   padding:.5rem .9rem;
   border-radius:999px;
   cursor:pointer;
+  transition:background-color .2s ease, color .2s ease;
 }
-.tab.active{outline:2px solid var(--accent)}
+.tab:hover{
+  background:var(--accent);
+  color:var(--bg);
+}
+.tab.active{
+  background:var(--accent);
+  color:var(--bg);
+}
 #content{padding:1rem clamp(1rem, 3vw, 2rem) 2rem}
 .panel{display:none; animation:fade .2s ease-in}
 .panel.active{display:block}
@@ -69,6 +77,13 @@ h1{font-size:1.2rem; margin:0; letter-spacing:.3px}
   grid-template-columns:repeat(auto-fill, minmax(260px, 1fr));
   margin-top:1rem;
 }
+.hero{
+  display:grid;
+  gap:1rem;
+  grid-template-columns:repeat(auto-fit, minmax(260px, 1fr));
+  padding:2rem clamp(1rem, 3vw, 2rem);
+}
+.hero .card{min-height:140px}
 .card{
   display:block;
   background:linear-gradient(180deg, #111a2d, #0d1526);
@@ -78,8 +93,13 @@ h1{font-size:1.2rem; margin:0; letter-spacing:.3px}
   text-decoration:none;
   color:var(--text);
   min-height:110px;
+  transition:transform .2s ease, border-color .2s ease, box-shadow .2s ease;
 }
-.card:hover{border-color:var(--accent)}
+.card:hover{
+  border-color:var(--accent);
+  transform:translateY(-4px);
+  box-shadow:0 4px 12px rgba(0,0,0,.4);
+}
 .card-title{font-weight:600; margin-bottom:.25rem}
 .card-meta{color:var(--muted); font-size:.92rem}
 .app-footer{
@@ -88,6 +108,10 @@ h1{font-size:1.2rem; margin:0; letter-spacing:.3px}
   color:var(--muted);
   display:flex;
   justify-content:space-between;
+}
+@media (max-width:768px){
+  .hero{grid-template-columns:1fr}
+  .tabs{overflow-x:auto}
 }
 @media (max-width:640px){
   #search{min-width:140px}


### PR DESCRIPTION
## Summary
- add hero section at top of page using grid layout to showcase key resources
- smooth tab and card interactions via CSS transitions and hover effects
- introduce responsive breakpoints for hero grid and tab navigation

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895dc6c0ac0832ca3787f5bb13e61f8