### PR TITLE
Add hero banner with transitions and responsive updates

### DIFF
--- a/cisadex/index.html
+++ b/cisadex/index.html
@@ -13,57 +13,78 @@
       <img src="assets/cisa.svg" alt="CISA" class="logo" />
       <h1>CISA Navigator</h1>
     </div>
-    <input id="search" type="search" placeholder="Search CISA (programs, sectors, SCC/GCC, JCDC, docs)..." aria-label="Search" />
+    <input
+      id="search"
+      type="search"
+      placeholder="Search CISA (programs, sectors, SCC/GCC, JCDC, docs)..."
+      aria-label="Search"
+    />
   </header>
 
+  <section class="hero" aria-labelledby="hero-heading">
+    <h2 id="hero-heading" class="sr-only">Featured Resources</h2>
+    <a href="https://www.cisa.gov/report" class="card" target="_blank" rel="noopener">
+      <div class="card-title">Report a Cyber Incident</div>
+      <div class="card-meta">24/7 portal for suspected intrusions or ransomware incidents.</div>
+    </a>
+    <a href="https://www.cisa.gov/cyber-hygiene-services" class="card" target="_blank" rel="noopener">
+      <div class="card-title">Cyber Hygiene Services</div>
+      <div class="card-meta">Free vulnerability scanning and mitigation resources.</div>
+    </a>
+    <a href="https://www.cisa.gov/training-exercises" class="card" target="_blank" rel="noopener">
+      <div class="card-title">Training & Exercises</div>
+      <div class="card-meta">Courses and exercises to build cybersecurity skills.</div>
+    </a>
+  </section>
+
   <nav class="tabs" role="tablist" aria-label="Primary">
-    <button class="tab active" data-panel="respond">Respond</button>
-    <button class="tab" data-panel="prepare">Prepare</button>
-    <button class="tab" data-panel="protect">Protect</button>
-    <button class="tab" data-panel="inform">Inform</button>
-    <button class="tab" data-panel="learn">Learn</button>
-    <button class="tab" data-panel="partner">Partner</button>
-    <button class="tab" data-panel="about">About CISA</button>
+    <button class="tab active" id="tab-respond" role="tab" data-panel="respond" aria-controls="respond" aria-selected="true" tabindex="0">Respond</button>
+    <button class="tab" id="tab-prepare" role="tab" data-panel="prepare" aria-controls="prepare" aria-selected="false" tabindex="-1">Prepare</button>
+    <button class="tab" id="tab-protect" role="tab" data-panel="protect" aria-controls="protect" aria-selected="false" tabindex="-1">Protect</button>
+    <button class="tab" id="tab-inform" role="tab" data-panel="inform" aria-controls="inform" aria-selected="false" tabindex="-1">Inform</button>
+    <button class="tab" id="tab-learn" role="tab" data-panel="learn" aria-controls="learn" aria-selected="false" tabindex="-1">Learn</button>
+    <button class="tab" id="tab-partner" role="tab" data-panel="partner" aria-controls="partner" aria-selected="false" tabindex="-1">Partner</button>
+    <button class="tab" id="tab-about" role="tab" data-panel="about" aria-controls="about" aria-selected="false" tabindex="-1">About CISA</button>
   </nav>
 
   <main id="content">
-    <section id="respond" class="panel active" tabindex="0" aria-labelledby="tab-respond">
+    <section id="respond" class="panel active" role="tabpanel" tabindex="0" aria-labelledby="tab-respond">
       <h2>Respond</h2>
       <p>Incident response, reporting, and on-call resources.</p>
       <div class="grid" data-category="respond"></div>
     </section>
 
-    <section id="prepare" class="panel" tabindex="0" aria-labelledby="tab-prepare">
+    <section id="prepare" class="panel" role="tabpanel" tabindex="0" aria-labelledby="tab-prepare" hidden>
       <h2>Prepare</h2>
       <p>Guides, playbooks, exercises, and critical infrastructure resilience.</p>
       <div class="grid" data-category="prepare"></div>
     </section>
 
-    <section id="protect" class="panel" tabindex="0" aria-labelledby="tab-protect">
+    <section id="protect" class="panel" role="tabpanel" tabindex="0" aria-labelledby="tab-protect" hidden>
       <h2>Protect</h2>
       <p>Cyber hygiene services, vulnerability management, KEV catalog, advisories.</p>
       <div class="grid" data-category="protect"></div>
     </section>
 
-    <section id="inform" class="panel" tabindex="0" aria-labelledby="tab-inform">
+    <section id="inform" class="panel" role="tabpanel" tabindex="0" aria-labelledby="tab-inform" hidden>
       <h2>Inform</h2>
       <p>Alerts, advisories, blog posts, press releases, ICS/OT advisories.</p>
       <div class="grid" data-category="inform"></div>
     </section>
 
-    <section id="learn" class="panel" tabindex="0" aria-labelledby="tab-learn">
+    <section id="learn" class="panel" role="tabpanel" tabindex="0" aria-labelledby="tab-learn" hidden>
       <h2>Learn</h2>
       <p>Training courses, awareness materials, and tabletop exercises.</p>
       <div class="grid" data-category="learn"></div>
     </section>
 
-    <section id="partner" class="panel" tabindex="0" aria-labelledby="tab-partner">
+    <section id="partner" class="panel" role="tabpanel" tabindex="0" aria-labelledby="tab-partner" hidden>
       <h2>Partner</h2>
       <p>JCDC, SCC/GCC, ISACs/ISAOs, and public-private programs.</p>
       <div class="grid" data-category="partner"></div>
     </section>
 
-    <section id="about" class="panel" tabindex="0" aria-labelledby="tab-about">
+    <section id="about" class="panel" role="tabpanel" tabindex="0" aria-labelledby="tab-about" hidden>
       <h2>About CISA</h2>
       <p>What CISA is, how it’s organized, and where to go next.</p>
       <div class="grid" data-category="about"></div>

--- a/cisadex/script.js
+++ b/cisadex/script.js
@@ -8,8 +8,17 @@ let DATA = [];
 let filtered = [];
 
 function setActive(id){
-  tabs.forEach(t => t.classList.toggle('active', t.dataset.panel === id));
-  panels.forEach(p => p.classList.toggle('active', p.id === id));
+  tabs.forEach(t => {
+    const active = t.dataset.panel === id;
+    t.classList.toggle('active', active);
+    t.setAttribute('aria-selected', active);
+    t.setAttribute('tabindex', active ? '0' : '-1');
+  });
+  panels.forEach(p => {
+    const isActive = p.id === id;
+    p.classList.toggle('active', isActive);
+    p.toggleAttribute('hidden', !isActive);
+  });
 }
 
 tabs.forEach(t => t.addEventListener('click', () => setActive(t.dataset.panel)));

--- a/cisadex/style.css
+++ b/cisadex/style.css
@@ -10,6 +10,17 @@
   --border:#213055;
 }
 *{box-sizing:border-box}
+.sr-only{
+  position:absolute;
+  width:1px;
+  height:1px;
+  padding:0;
+  margin:-1px;
+  overflow:hidden;
+  clip:rect(0 0 0 0);
+  white-space:nowrap;
+  border:0;
+}
 html,body{height:100%}
 body{
   margin:0;
@@ -57,8 +68,16 @@ h1{font-size:1.2rem; margin:0; letter-spacing:.3px}
   padding:.5rem .9rem;
   border-radius:999px;
   cursor:pointer;
+  transition:background-color .2s ease, color .2s ease;
 }
-.tab.active{outline:2px solid var(--accent)}
+.tab:hover{
+  background:var(--accent);
+  color:var(--bg);
+}
+.tab.active{
+  background:var(--accent);
+  color:var(--bg);
+}
 #content{padding:1rem clamp(1rem, 3vw, 2rem) 2rem}
 .panel{display:none; animation:fade .2s ease-in}
 .panel.active{display:block}
@@ -69,6 +88,13 @@ h1{font-size:1.2rem; margin:0; letter-spacing:.3px}
   grid-template-columns:repeat(auto-fill, minmax(260px, 1fr));
   margin-top:1rem;
 }
+.hero{
+  display:grid;
+  gap:1rem;
+  grid-template-columns:repeat(auto-fit, minmax(260px, 1fr));
+  padding:2rem clamp(1rem, 3vw, 2rem);
+}
+.hero .card{min-height:140px}
 .card{
   display:block;
   background:linear-gradient(180deg, #111a2d, #0d1526);
@@ -78,8 +104,13 @@ h1{font-size:1.2rem; margin:0; letter-spacing:.3px}
   text-decoration:none;
   color:var(--text);
   min-height:110px;
+  transition:transform .2s ease, border-color .2s ease, box-shadow .2s ease;
 }
-.card:hover{border-color:var(--accent)}
+.card:hover{
+  border-color:var(--accent);
+  transform:translateY(-4px);
+  box-shadow:0 4px 12px rgba(0,0,0,.4);
+}
 .card-title{font-weight:600; margin-bottom:.25rem}
 .card-meta{color:var(--muted); font-size:.92rem}
 .app-footer{
@@ -88,6 +119,16 @@ h1{font-size:1.2rem; margin:0; letter-spacing:.3px}
   color:var(--muted);
   display:flex;
   justify-content:space-between;
+}
+@media (prefers-reduced-motion: reduce){
+  .tab,
+  .card{transition:none}
+  .card:hover{transform:none}
+  .panel{animation:none}
+}
+@media (max-width:768px){
+  .hero{grid-template-columns:1fr}
+  .tabs{overflow-x:auto}
 }
 @media (max-width:640px){
   #search{min-width:140px}


### PR DESCRIPTION
## Summary
- add hero section at top of page using grid layout to showcase key resources
- smooth tab and card interactions via CSS transitions and hover effects
- introduce responsive breakpoints for hero grid and tab navigation
- enhance accessibility with ARIA roles, labels, and reduced-motion support

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895dc6c0ac0832ca3787f5bb13e61f8