### PR TITLE
Add hero UI, RSS proxy, and publications feed

### DIFF
--- a/cisadex/functions/api/rss.js
+++ b/cisadex/functions/api/rss.js
@@ -1,0 +1,44 @@
+// Cloudflare Pages Function: /api/rss?url=<encoded RSS URL>
+// Example: /api/rss?url=https%3A%2F%2Fwww.cisa.gov%2Fnews-events%2Fnews.xml
+export async function onRequestGet(context) {
+  try {
+    const { request, env } = context;
+    const { searchParams } = new URL(request.url);
+    const url = searchParams.get("url");
+
+    if (!url) {
+      return new Response(JSON.stringify({ error: "Missing ?url=" }), {
+        status: 400,
+        headers: corsHeaders("application/json"),
+      });
+    }
+
+    const upstream = await fetch(url, {
+      headers: { "User-Agent": "CISAdex RSS Fetcher" },
+    });
+
+    if (!upstream.ok) {
+      return new Response(JSON.stringify({ error: `Upstream ${upstream.status}` }), {
+        status: 502,
+        headers: corsHeaders("application/json"),
+      });
+    }
+
+    // Just proxy XML through; the client will parse it.
+    const xml = await upstream.text();
+    return new Response(xml, { headers: corsHeaders("application/xml") });
+  } catch (err) {
+    return new Response(JSON.stringify({ error: String(err) }), {
+      status: 500,
+      headers: corsHeaders("application/json"),
+    });
+  }
+}
+
+function corsHeaders(type = "text/plain") {
+  return {
+    "content-type": type,
+    "access-control-allow-origin": "*",
+    "cache-control": "public, max-age=300", // 5 min edge cache
+  };
+}

--- a/cisadex/index.html
+++ b/cisadex/index.html
@@ -13,7 +13,6 @@
       <img src="assets/cisa.svg" alt="CISA" class="logo" />
       <h1>CISA Navigator</h1>
     </div>
-    <input id="search" type="search" placeholder="Search CISA (programs, sectors, SCC/GCC, JCDC, docs)..." aria-label="Search" />
   </header>
 
   <nav class="tabs" role="tablist" aria-label="Primary">
@@ -23,10 +22,65 @@
     <button class="tab" data-panel="inform">Inform</button>
     <button class="tab" data-panel="learn">Learn</button>
     <button class="tab" data-panel="partner">Partner</button>
+    <button class="tab" data-panel="publications">Publications</button>
     <button class="tab" data-panel="about">About CISA</button>
   </nav>
 
   <main id="content">
+    <!-- HERO -->
+    <section class="hero">
+      <div class="hero-copy">
+        <h1>CISA Navigator</h1>
+        <p>Explore CISA’s services, sectors, and guidance—organized by mission outcomes and NIST CSF 2.0 functions.</p>
+        <div class="hero-actions">
+          <input id="globalSearch" class="input" type="search" placeholder="Search CISA content…" />
+          <button id="searchBtn" class="btn primary">Search</button>
+        </div>
+        <div class="chip-row" id="csfChips">
+          <button class="chip" data-csf="ID">Identify</button>
+          <button class="chip" data-csf="PR">Protect</button>
+          <button class="chip" data-csf="DE">Detect</button>
+          <button class="chip" data-csf="RS">Respond</button>
+          <button class="chip" data-csf="RC">Recover</button>
+          <button class="chip" data-csf="GV">Govern</button>
+        </div>
+      </div>
+      <div class="hero-art">
+        <img src="assets/cisa.svg" alt="CISA" />
+      </div>
+    </section>
+
+    <!-- SECTORS SHOWCASE -->
+    <section class="panel active">
+      <header class="panel-head">
+        <h2>Critical Infrastructure Sectors</h2>
+        <a class="link" href="https://www.cisa.gov/topics/critical-infrastructure-security-and-resilience/critical-infrastructure-sectors" target="_blank">All Sectors</a>
+      </header>
+      <div id="sectorsGrid" class="tile-grid sectors"></div>
+    </section>
+
+    <!-- SERVICES QUICK ACCESS -->
+    <section class="panel active">
+      <header class="panel-head">
+        <h2>Popular CISA Services</h2>
+        <a class="link" href="https://www.cisa.gov/resources-tools" target="_blank">Browse Library</a>
+      </header>
+      <div id="servicesGrid" class="tile-grid services"></div>
+    </section>
+
+    <!-- LIVE FEED -->
+    <section class="panel active">
+      <header class="panel-head">
+        <h2>Latest from CISA</h2>
+        <div class="feed-tabs">
+          <button class="tab active" data-feed="news">News</button>
+          <button class="tab" data-feed="alerts">Advisories & Alerts</button>
+          <button class="tab" data-feed="updates">CISA Updates</button>
+        </div>
+      </header>
+      <ul id="rssList" class="rss-list"></ul>
+    </section>
+
     <section id="respond" class="panel active" tabindex="0" aria-labelledby="tab-respond">
       <h2>Respond</h2>
       <p>Incident response, reporting, and on-call resources.</p>
@@ -61,6 +115,12 @@
       <h2>Partner</h2>
       <p>JCDC, SCC/GCC, ISACs/ISAOs, and public-private programs.</p>
       <div class="grid" data-category="partner"></div>
+    </section>
+
+    <section id="publications" class="panel" tabindex="0" aria-labelledby="tab-publications">
+      <h2>Publications</h2>
+      <p>Latest CISA publications.</p>
+      <div id="publications-feed" class="feed"></div>
     </section>
 
     <section id="about" class="panel" tabindex="0" aria-labelledby="tab-about">

--- a/cisadex/script.js
+++ b/cisadex/script.js
@@ -1,7 +1,6 @@
 
-const tabs = document.querySelectorAll('.tab');
-const panels = document.querySelectorAll('.panel');
-const search = document.getElementById('search');
+const tabs = document.querySelectorAll('nav.tabs .tab');
+const panels = document.querySelectorAll('.panel[id]');
 const tpl = document.getElementById('card-template');
 
 let DATA = [];
@@ -27,6 +26,25 @@ async function load(){
   }
 }
 
+async function loadRss(){
+  try{
+    const url = encodeURIComponent('https://www.cisa.gov/rss-feed.xml');
+    const res = await fetch(`/api/rss?url=${url}`);
+    const text = await res.text();
+    const doc = new DOMParser().parseFromString(text, 'application/xml');
+    const items = [...doc.querySelectorAll('item')].map(item => ({
+      title: item.querySelector('title')?.textContent || '',
+      url: item.querySelector('link')?.textContent || '',
+      date: item.querySelector('pubDate')?.textContent || ''
+    }));
+    renderPublications(items.slice(0, 10));
+  }catch(e){
+    console.error(e);
+    const feed = document.getElementById('publications-feed');
+    if (feed) feed.textContent = 'Failed to load publications feed.';
+  }
+}
+
 function makeCard(item){
   const node = tpl.content.firstElementChild.cloneNode(true);
   node.href = item.url;
@@ -36,12 +54,34 @@ function makeCard(item){
 }
 
 function renderAll(list = filtered){
-  const byCat = panels;
   panels.forEach(p => {
     const grid = p.querySelector('.grid');
+    if(!grid) return;
     const cat = grid.dataset.category;
     grid.innerHTML = '';
     list.filter(x => x.category === cat).forEach(x => grid.appendChild(makeCard(x)));
+  });
+}
+
+function renderPublications(list){
+  const feed = document.getElementById('publications-feed');
+  if(!feed) return;
+  feed.innerHTML = '';
+  list.forEach(item => {
+    const a = document.createElement('a');
+    a.className = 'feed-item';
+    a.href = item.url;
+    a.target = '_blank';
+    a.rel = 'noopener';
+    const title = document.createElement('div');
+    title.className = 'title';
+    title.textContent = item.title;
+    const date = document.createElement('div');
+    date.className = 'date';
+    date.textContent = item.date ? new Date(item.date).toLocaleDateString() : '';
+    a.appendChild(title);
+    a.appendChild(date);
+    feed.appendChild(a);
   });
 }
 
@@ -54,6 +94,153 @@ function onSearch(q){
   renderAll(filtered);
 }
 
-search.addEventListener('input', (e)=> onSearch(e.target.value));
+window.addEventListener('global-search', e => onSearch(e.detail.q));
+
+window.addEventListener('csf-filter', e => {
+  const code = e.detail.csf;
+  if(!code){ filtered = DATA.items; renderAll(); return; }
+  filtered = DATA.items.filter(x => (x.csf||[]).includes(code));
+  renderAll(filtered);
+});
+
+// ---------- Config ----------
+const FEEDS = {
+  news: "https://www.cisa.gov/news-events/news.xml",
+  alerts: "https://www.cisa.gov/news-events/cybersecurity-advisories.xml",
+  updates: "https://www.cisa.gov/news-events/cisa-updates.xml"
+};
+
+// Sectors quick data (icon = emoji for now; swap to SVG later)
+const SECTORS = [
+  { key:"Energy", icon:"⚡", url:"https://www.cisa.gov/energy-sector", blurb:"Electricity, oil & gas operations." },
+  { key:"Water & Wastewater", icon:"💧", url:"https://www.cisa.gov/water-and-wastewater-systems-sector", blurb:"Treatment & distribution." },
+  { key:"Communications", icon:"📡", url:"https://www.cisa.gov/communications-sector", blurb:"Telecom & broadcast." },
+  { key:"Information Technology", icon:"💻", url:"https://www.cisa.gov/information-technology-sector", blurb:"IT providers & platforms." },
+  { key:"Transportation Systems", icon:"🚆", url:"https://www.cisa.gov/transportation-systems-sector", blurb:"Aviation, rail, maritime, pipeline." },
+  { key:"Chemical", icon:"🧪", url:"https://www.cisa.gov/chemical-sector", blurb:"Production & storage." },
+  { key:"Critical Manufacturing", icon:"🏭", url:"https://www.cisa.gov/critical-manufacturing-sector", blurb:"Industrial production." },
+  { key:"Healthcare & Public Health", icon:"🏥", url:"https://www.cisa.gov/healthcare-and-public-health-sector", blurb:"Hospitals & labs." },
+  { key:"Financial Services", icon:"💳", url:"https://www.cisa.gov/financial-services-sector", blurb:"Banking & markets." },
+  { key:"Food & Agriculture", icon:"🌾", url:"https://www.cisa.gov/food-and-agriculture-sector", blurb:"Farms & processing." },
+  { key:"Dams", icon:"🏞️", url:"https://www.cisa.gov/dams-sector", blurb:"Reservoirs & flood control." },
+  { key:"Nuclear", icon:"☢️", url:"https://www.cisa.gov/nuclear-reactors-materials-and-waste-sector", blurb:"Nuclear facilities." },
+  { key:"Government Facilities", icon:"🏛️", url:"https://www.cisa.gov/government-facilities-sector", blurb:"Federal & SLTT." },
+  { key:"Commercial Facilities", icon:"🏬", url:"https://www.cisa.gov/commercial-facilities-sector", blurb:"Malls, venues, offices." },
+  { key:"Defense Industrial Base", icon:"🛡️", url:"https://www.cisa.gov/defense-industrial-base-sector", blurb:"DoD supply chain." },
+  { key:"Emergency Services", icon:"🚒", url:"https://www.cisa.gov/emergency-services-sector", blurb:"Police, fire, EMS, PSAPs." }
+];
+
+const SERVICES = [
+  { k:"Service", t:"Cyber Hygiene (Free)", p:"External attack surface scanning & vuln reporting.", url:"https://www.cisa.gov/cyber-hygiene-services" },
+  { k:"Service", t:"KEV Catalog", p:"Patch first: vulnerabilities known to be exploited.", url:"https://www.cisa.gov/kev" },
+  { k:"Service", t:"Shields Up", p:"Heightened posture guidance & time-bound actions.", url:"https://www.cisa.gov/shields-up" },
+  { k:"Service", t:"CPGs", p:"Prioritized goals for critical infrastructure risk reduction.", url:"https://www.cisa.gov/cpg" },
+  { k:"Service", t:"CTEP Tabletop Kits", p:"Plug-and-play exercise materials to test readiness.", url:"https://www.cisa.gov/resources-tools/resources/tabletop-exercises" },
+  { k:"Service", t:"Stop Ransomware", p:"Prevention, response, and recovery resources.", url:"https://www.stopransomware.gov/" }
+];
+
+// ---------- DOM Helpers ----------
+const el = (sel) => document.querySelector(sel);
+const list = (sel) => document.querySelectorAll(sel);
+
+function tileHTML(item, variant="sector"){
+  if (variant === "sector") {
+    return `<a class="tile" href="${item.url}" target="_blank" rel="noopener">
+      <div class="k"><span class="icon">${item.icon}</span>${item.key}</div>
+      <div class="p">${item.blurb}</div></a>`;
+  }
+  return `<a class="tile" href="${item.url}" target="_blank" rel="noopener">
+      <div class="k">${item.k}</div>
+      <div class="t">${item.t}</div>
+      <div class="p">${item.p}</div></a>`;
+}
+
+// ---------- Render static tiles ----------
+function renderSectors(){
+  el("#sectorsGrid").innerHTML = SECTORS.map(s => tileHTML(s,"sector")).join("");
+}
+function renderServices(){
+  el("#servicesGrid").innerHTML = SERVICES.map(s => tileHTML(s,"service")).join("");
+}
+
+// ---------- RSS (client parses XML) ----------
+async function loadFeed(kind="news"){
+  const rssUrl = FEEDS[kind];
+  if (!rssUrl) return;
+  const endpoint = `/api/rss?url=${encodeURIComponent(rssUrl)}`;
+  const res = await fetch(endpoint);
+  const xml = await res.text();
+
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(xml, "text/xml");
+
+  const items = [...doc.querySelectorAll("item")];
+  const entries = items.length ? items : [...doc.querySelectorAll("entry")];
+
+  const max = 8;
+  const out = entries.slice(0,max).map(n => {
+    const title = (n.querySelector("title")?.textContent || "").trim();
+    const link = (n.querySelector("link")?.textContent || n.querySelector("link")?.getAttribute("href") || "#").trim();
+    const pubRaw = (n.querySelector("pubDate")?.textContent || n.querySelector("updated")?.textContent || "").trim();
+    const date = pubRaw ? new Date(pubRaw) : null;
+    const nice = date ? date.toLocaleDateString(undefined, {year:"numeric", month:"short", day:"numeric"}) : "";
+    const source = kind === "alerts" ? "Advisory" : (kind === "updates" ? "Update" : "News");
+
+    return `<li class="rss-item">
+      <a href="${link}" target="_blank" rel="noopener">${escapeHTML(title)}</a>
+      <div class="rss-meta">${source}${nice ? ` • ${nice}` : ""}</div>
+    </li>`;
+  }).join("");
+
+  el("#rssList").innerHTML = out || `<li class="rss-item">No items found.</li>`;
+}
+
+function escapeHTML(s){ return s.replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;','\'':'&#039;'}[m])) }
+
+// ---------- CSF chips -> filter your existing catalog ----------
+function wireCSFChips(){
+  const chips = list("#csfChips .chip");
+  chips.forEach(ch => ch.addEventListener("click", () => {
+    chips.forEach(c => c.classList.remove("active"));
+    ch.classList.add("active");
+    const code = ch.dataset.csf;
+    const ev = new CustomEvent("csf-filter", { detail: { csf: code }});
+    window.dispatchEvent(ev);
+  }));
+}
+
+// ---------- Tabs for feeds ----------
+function wireFeedTabs(){
+  const tabs = list(".feed-tabs .tab");
+  tabs.forEach(t => t.addEventListener("click", async () => {
+    tabs.forEach(x => x.classList.remove("active"));
+    t.classList.add("active");
+    await loadFeed(t.dataset.feed);
+  }));
+}
+
+// ---------- Search (simple hook) ----------
+function wireSearch(){
+  const q = el("#globalSearch");
+  const btn = el("#searchBtn");
+  const go = () => {
+    const term = (q.value || "").trim();
+    const ev = new CustomEvent("global-search", { detail: { q: term }});
+    window.dispatchEvent(ev);
+  };
+  btn.addEventListener("click", go);
+  q.addEventListener("keydown", e => (e.key === "Enter") && go());
+}
+
+// ---------- Init ----------
+document.addEventListener("DOMContentLoaded", async () => {
+  renderSectors();
+  renderServices();
+  wireFeedTabs();
+  wireCSFChips();
+  wireSearch();
+  await loadFeed("news");
+});
 
 load();
+loadRss();

--- a/cisadex/style.css
+++ b/cisadex/style.css
@@ -82,6 +82,25 @@ h1{font-size:1.2rem; margin:0; letter-spacing:.3px}
 .card:hover{border-color:var(--accent)}
 .card-title{font-weight:600; margin-bottom:.25rem}
 .card-meta{color:var(--muted); font-size:.92rem}
+
+.feed{
+  display:flex;
+  flex-direction:column;
+  gap:.5rem;
+  margin-top:1rem;
+}
+.feed-item{
+  display:block;
+  padding:.75rem 1rem;
+  background:var(--panel);
+  border:1px solid var(--border);
+  border-radius:10px;
+  text-decoration:none;
+  color:var(--text);
+}
+.feed-item:hover{border-color:var(--accent)}
+.feed-item .title{font-weight:600}
+.feed-item .date{color:var(--muted); font-size:.85rem}
 .app-footer{
   padding:1rem clamp(1rem, 3vw, 2rem);
   border-top:1px solid var(--border);
@@ -92,3 +111,53 @@ h1{font-size:1.2rem; margin:0; letter-spacing:.3px}
 @media (max-width:640px){
   #search{min-width:140px}
 }
+
+:root{
+  --bg:#0b1220; --card:#101a2f; --muted:#a9b3c6; --text:#eaf0ff; --accent:#64b5ff; --chip:#1a2847;
+  --ring: rgba(100,181,255,.35);
+}
+.hero{
+  display:grid; grid-template-columns: 1.2fr .8fr; gap:2rem; align-items:center; padding:2.5rem 1rem 1rem;
+  border-bottom:1px solid #16223c;
+}
+.hero h1{ font-size:2rem; margin:.25rem 0 .5rem 0; }
+.hero p{ color:var(--muted); max-width:46ch }
+.hero-actions{ display:flex; gap:.5rem; margin:1rem 0 1rem }
+.input{ background:#0e1730; border:1px solid #172445; color:var(--text); padding:.7rem .9rem; border-radius:.75rem; width:100%; }
+.input:focus{ outline:none; box-shadow:0 0 0 .2rem var(--ring); }
+.btn{ border:none; padding:.7rem 1rem; border-radius:.7rem; cursor:pointer; }
+.btn.primary{ background:linear-gradient(135deg,#2b65f6,#64b5ff); color:#fff; }
+.hero-art img{ max-width:100%; opacity:.9; filter:drop-shadow(0 12px 24px rgba(0,0,0,.25)); }
+
+.chip-row{ display:flex; gap:.5rem; flex-wrap:wrap; }
+.chip{ background:var(--chip); color:#cfe1ff; border:1px solid #1f2c4e; border-radius:2rem; padding:.4rem .8rem; cursor:pointer; }
+.chip.active{ border-color:var(--accent); box-shadow:0 0 0 .15rem var(--ring); }
+
+.panel{ padding:1.25rem 1rem; }
+.panel-head{ display:flex; justify-content:space-between; align-items:center; margin-bottom:.8rem; }
+.link{ color:#8ec7ff; text-decoration:none; }
+.tile-grid{ display:grid; gap:.8rem; }
+.tile-grid.sectors{ grid-template-columns: repeat(auto-fill,minmax(170px,1fr)); }
+.tile-grid.services{ grid-template-columns: repeat(auto-fill,minmax(230px,1fr)); }
+.tile{
+  background:var(--card); border:1px solid #17223d; border-radius:1rem; padding:1rem;
+  transition:transform .15s ease, box-shadow .15s ease, border-color .15s ease;
+}
+.tile:hover{ transform:translateY(-2px); border-color:#22406b; box-shadow:0 6px 22px rgba(12,22,40,.45); }
+.tile .k{ font-size:.75rem; color:var(--muted); letter-spacing:.04em; text-transform:uppercase }
+.tile .t{ font-weight:600; margin:.2rem 0 .4rem 0 }
+.tile .p{ color:#b8c7e4; font-size:.9rem }
+
+.icon{
+  width:28px; height:28px; border-radius:.6rem; display:inline-grid; place-items:center; margin-right:.5rem;
+  background:linear-gradient(135deg,#20355f,#2a4f8e); color:#cfe1ff; border:1px solid #2b477d;
+}
+
+.feed-tabs{ display:flex; gap:.6rem; }
+.tab{ background:#0f1830; color:#cfe1ff; border:1px solid #1c2b4e; border-radius:.6rem; padding:.45rem .7rem; cursor:pointer; }
+.tab.active{ border-color:#3a64a7; }
+
+.rss-list{ list-style:none; margin:0; padding:0; display:grid; gap:.6rem; }
+.rss-item{ background:var(--card); border:1px solid #17223d; border-radius:.9rem; padding:.8rem 1rem; }
+.rss-item a{ color:#d7e7ff; font-weight:600; text-decoration:none; }
+.rss-meta{ color:#8ea3c9; font-size:.85rem; margin-top:.1rem }


### PR DESCRIPTION
## Summary
- Add Cloudflare Pages Function to proxy RSS requests with permissive CORS headers
- Introduce hero, sector, services, and live feed sections with search and chips
- Fetch and render latest CISA publications via new tab, panel, and RSS parsing helpers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895dc6a3a80832cb30578d1a199852d