### PR TITLE
feat: add dark-mode field presence map

### DIFF
--- a/cisadex/data/offices.json
+++ b/cisadex/data/offices.json
@@ -1,0 +1,125 @@
+{
+ "type": "FeatureCollection",
+ "features": [
+  {
+    "type": "Feature",
+    "geometry": {"type": "Point", "coordinates": [-75.1652, 39.9526]},
+    "properties": {
+      "id": "cisa-philadelphia",
+      "agency": "CISA",
+      "sub_agency": "",
+      "office_name": "CISA Region 3 Office",
+      "role_type": "Regional Office",
+      "sectors": ["Cross-Sector"],
+      "address": "1234 Market St",
+      "city": "Philadelphia",
+      "state": "PA",
+      "postal_code": "19107",
+      "lat": 39.9526,
+      "lng": -75.1652,
+      "region": "CISA Region 3",
+      "coverage": {"counties": [], "states": ["PA", "DE", "MD", "DC", "VA", "WV"]},
+      "contact_public": {"phone": "", "email": "", "website": "https://www.cisa.gov"},
+      "data_source": "Sample",
+      "last_verified_utc": "2025-08-08T00:00:00Z",
+      "notes_public": "Demo data"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {"type": "Point", "coordinates": [-87.6298, 41.8781]},
+    "properties": {
+      "id": "fbi-chicago",
+      "agency": "FBI",
+      "sub_agency": "",
+      "office_name": "FBI Chicago Field Office",
+      "role_type": "Field Office",
+      "sectors": ["Cross-Sector"],
+      "address": "2111 W Roosevelt Rd",
+      "city": "Chicago",
+      "state": "IL",
+      "postal_code": "60608",
+      "lat": 41.8781,
+      "lng": -87.6298,
+      "region": "FBI Chicago",
+      "coverage": {"counties": [], "states": ["IL"]},
+      "contact_public": {"phone": "(312) 421-6700", "email": "", "website": "https://www.fbi.gov/contact-us/field-offices/chicago"},
+      "data_source": "Sample",
+      "last_verified_utc": "2025-08-08T00:00:00Z",
+      "notes_public": "Demo data"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {"type": "Point", "coordinates": [-84.255, 35.93]},
+    "properties": {
+      "id": "ornl",
+      "agency": "DOE",
+      "sub_agency": "National Lab",
+      "office_name": "Oak Ridge National Laboratory",
+      "role_type": "National Laboratory",
+      "sectors": ["Energy"],
+      "address": "1 Bethel Valley Rd",
+      "city": "Oak Ridge",
+      "state": "TN",
+      "postal_code": "37830",
+      "lat": 35.93,
+      "lng": -84.255,
+      "region": "DOE",
+      "coverage": {"counties": [], "states": ["TN"]},
+      "contact_public": {"phone": "", "email": "", "website": "https://www.ornl.gov"},
+      "data_source": "Sample",
+      "last_verified_utc": "2025-08-08T00:00:00Z",
+      "notes_public": "Demo data"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {"type": "Point", "coordinates": [-118.2437, 34.0522]},
+    "properties": {
+      "id": "tsa-losangeles",
+      "agency": "TSA",
+      "sub_agency": "",
+      "office_name": "TSA Los Angeles Field Office",
+      "role_type": "Field Office",
+      "sectors": ["Transportation"],
+      "address": "Los Angeles, CA",
+      "city": "Los Angeles",
+      "state": "CA",
+      "postal_code": "90045",
+      "lat": 34.0522,
+      "lng": -118.2437,
+      "region": "TSA Western",
+      "coverage": {"counties": [], "states": ["CA"]},
+      "contact_public": {"phone": "", "email": "", "website": "https://www.tsa.gov"},
+      "data_source": "Sample",
+      "last_verified_utc": "2025-08-08T00:00:00Z",
+      "notes_public": "Demo data"
+    }
+  },
+  {
+    "type": "Feature",
+    "geometry": {"type": "Point", "coordinates": [-122.3321, 47.6062]},
+    "properties": {
+      "id": "epa-seattle",
+      "agency": "EPA",
+      "sub_agency": "",
+      "office_name": "EPA Region 10 Office",
+      "role_type": "Regional Office",
+      "sectors": ["Water"],
+      "address": "1200 Sixth Ave",
+      "city": "Seattle",
+      "state": "WA",
+      "postal_code": "98101",
+      "lat": 47.6062,
+      "lng": -122.3321,
+      "region": "EPA Region 10",
+      "coverage": {"counties": [], "states": ["WA", "OR", "ID", "AK"]},
+      "contact_public": {"phone": "", "email": "", "website": "https://www.epa.gov"},
+      "data_source": "Sample",
+      "last_verified_utc": "2025-08-08T00:00:00Z",
+      "notes_public": "Demo data"
+    }
+  }
+ ]
+}

--- a/cisadex/map.css
+++ b/cisadex/map.css
@@ -1,0 +1,8 @@
+html, body { height: 100%; margin: 0; }
+#map { position: absolute; top: 0; bottom: 0; width: 100%; }
+#filters { position: absolute; top: 10px; left: 10px; background: rgba(0,0,0,0.7); color: #fff; padding: 10px; border-radius: 4px; font-family: sans-serif; z-index: 1; max-width: 320px; }
+#filters label { display: block; margin-bottom: 6px; font-size: 12px; }
+#filters select, #filters input { width: 100%; margin-top: 2px; background: #222; color: #fff; border: 1px solid #555; }
+#details { position: absolute; right: 0; top: 0; bottom: 0; width: 300px; background: rgba(0,0,0,0.85); color: #fff; overflow-y: auto; padding: 10px; transform: translateX(100%); transition: transform 0.3s; z-index: 1; font-family: sans-serif; }
+#details.open { transform: translateX(0); }
+#details h3 { margin-top: 0; }

--- a/cisadex/map.html
+++ b/cisadex/map.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Federal Field Presence Map</title>
+  <link href="https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.css" rel="stylesheet" />
+  <link rel="stylesheet" href="map.css" />
+</head>
+<body>
+  <div id="map"></div>
+  <div id="filters">
+    <input id="search" type="search" placeholder="Search city, state, ZIP" aria-label="Search" />
+    <label>Agency<select id="agency-filter" multiple></select></label>
+    <label>Role<select id="role-filter" multiple></select></label>
+    <label>Sector<select id="sector-filter" multiple></select></label>
+    <label>Region<select id="region-filter" multiple></select></label>
+  </div>
+  <div id="details" class="details"></div>
+
+  <script src="https://unpkg.com/maplibre-gl@2.4.0/dist/maplibre-gl.js"></script>
+  <script src="map.js"></script>
+</body>
+</html>

--- a/cisadex/map.js
+++ b/cisadex/map.js
@@ -1,0 +1,167 @@
+let map;
+let allFeatures = [];
+
+function getSelected(id){
+  const select = document.getElementById(id);
+  return Array.from(select.selectedOptions).map(o => o.value);
+}
+
+function populateFilters(){
+  const agencies = new Set();
+  const roles = new Set();
+  const sectors = new Set();
+  const regions = new Set();
+  allFeatures.forEach(f => {
+    const p = f.properties;
+    agencies.add(p.agency);
+    roles.add(p.role_type);
+    p.sectors.forEach(s => sectors.add(s));
+    regions.add(p.region);
+  });
+  fillSelect('agency-filter', agencies);
+  fillSelect('role-filter', roles);
+  fillSelect('sector-filter', sectors);
+  fillSelect('region-filter', regions);
+}
+
+function fillSelect(id, values){
+  const select = document.getElementById(id);
+  Array.from(values).sort().forEach(v => {
+    const opt = document.createElement('option');
+    opt.value = v;
+    opt.textContent = v;
+    opt.selected = true;
+    select.appendChild(opt);
+  });
+  select.addEventListener('change', applyFilters);
+}
+
+function applyFilters(){
+  const agencies = getSelected('agency-filter');
+  const roles = getSelected('role-filter');
+  const sectors = getSelected('sector-filter');
+  const regions = getSelected('region-filter');
+
+  const filtered = allFeatures.filter(f => {
+    const p = f.properties;
+    return (agencies.length ? agencies.includes(p.agency) : true) &&
+           (roles.length ? roles.includes(p.role_type) : true) &&
+           (sectors.length ? sectors.some(s => p.sectors.includes(s)) : true) &&
+           (regions.length ? regions.includes(p.region) : true);
+  });
+  map.getSource('offices').setData({type: 'FeatureCollection', features: filtered});
+}
+
+async function loadData(){
+  const res = await fetch('data/offices.json');
+  const geojson = await res.json();
+  allFeatures = geojson.features;
+  map.addSource('offices', {
+    type: 'geojson',
+    data: geojson,
+    cluster: true,
+    clusterMaxZoom: 6,
+    clusterRadius: 40
+  });
+
+  map.addLayer({
+    id: 'clusters',
+    type: 'circle',
+    source: 'offices',
+    filter: ['has', 'point_count'],
+    paint: {
+      'circle-color': '#444',
+      'circle-radius': ['step', ['get', 'point_count'], 15, 10, 20, 25, 25]
+    }
+  });
+
+  map.addLayer({
+    id: 'cluster-count',
+    type: 'symbol',
+    source: 'offices',
+    filter: ['has', 'point_count'],
+    layout: {
+      'text-field': ['get', 'point_count_abbreviated'],
+      'text-font': ['Open Sans Bold', 'Arial Unicode MS Bold'],
+      'text-size': 12
+    },
+    paint: { 'text-color': '#fff' }
+  });
+
+  map.addLayer({
+    id: 'unclustered',
+    type: 'circle',
+    source: 'offices',
+    filter: ['!', ['has', 'point_count']],
+    paint: {
+      'circle-color': '#00bcd4',
+      'circle-radius': 6,
+      'circle-stroke-width': 1,
+      'circle-stroke-color': '#fff'
+    }
+  });
+
+  const popup = new maplibregl.Popup({closeButton: false, closeOnClick: false});
+  map.on('mouseenter', 'unclustered', (e) => {
+    map.getCanvas().style.cursor = 'pointer';
+    const p = e.features[0].properties;
+    const html = `<strong>${p.office_name}</strong><br/>${p.agency} - ${p.city}, ${p.state}<br/>${p.role_type}`;
+    popup.setLngLat(e.features[0].geometry.coordinates).setHTML(html).addTo(map);
+  });
+  map.on('mouseleave', 'unclustered', () => {
+    map.getCanvas().style.cursor = '';
+    popup.remove();
+  });
+
+  map.on('click', 'clusters', (e) => {
+    const features = map.queryRenderedFeatures(e.point, {layers: ['clusters']});
+    const clusterId = features[0].properties.cluster_id;
+    map.getSource('offices').getClusterExpansionZoom(clusterId, (err, zoom) => {
+      if (err) return;
+      map.easeTo({center: features[0].geometry.coordinates, zoom});
+    });
+  });
+
+  map.on('click', 'unclustered', (e) => {
+    const p = e.features[0].properties;
+    const d = document.getElementById('details');
+    d.innerHTML = `<h3>${p.office_name}</h3>`+
+      `<p><strong>Agency:</strong> ${p.agency}</p>`+
+      `<p><strong>Role:</strong> ${p.role_type}</p>`+
+      `<p><strong>City:</strong> ${p.city}, ${p.state}</p>`+
+      `<p><strong>Sectors:</strong> ${p.sectors.join(', ')}</p>`+
+      `<p><strong>Region:</strong> ${p.region}</p>`;
+    d.classList.add('open');
+  });
+
+  populateFilters();
+}
+
+async function geocode(q){
+  const url = `https://nominatim.openstreetmap.org/search?format=json&limit=1&q=${encodeURIComponent(q)}`;
+  const res = await fetch(url);
+  const data = await res.json();
+  if(data[0]){
+    map.easeTo({center: [parseFloat(data[0].lon), parseFloat(data[0].lat)], zoom: 9});
+  }
+}
+
+function setupSearch(){
+  const s = document.getElementById('search');
+  s.addEventListener('keydown', (e) => {
+    if(e.key === 'Enter') geocode(s.value);
+  });
+}
+
+function init(){
+  map = new maplibregl.Map({
+    container: 'map',
+    style: 'https://basemaps.cartocdn.com/gl/dark-matter-gl-style/style.json',
+    center: [-98, 39],
+    zoom: 3
+  });
+  map.on('load', loadData);
+  setupSearch();
+}
+
+init();


### PR DESCRIPTION
## Summary
- add standalone dark-map page plotting sample federal field offices
- support clustering, hover details, and agency/role/sector/region filters
- include search geocoding and details drawer

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895f40eef34832c9b04e64d903a6c9c