### PR TITLE
Specify Node.js engine and document requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# Cisadex
+
+## Requirements
+
+This project requires [Node.js](https://nodejs.org/) version 18 or later. Ensure you have a compatible version installed before running the development or build scripts.
+
+## Development
+
+Install dependencies:
+
+```bash
+npm install
+```
+
+Start the development server:
+
+```bash
+npm run dev
+```
+
+Build for production:
+
+```bash
+npm run build
+```
+

--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
   "author": "",
   "license": "ISC",
   "type": "module",
+  "engines": {
+    "node": ">=18"
+  },
   "dependencies": {
     "maplibre-gl": "^5.6.2",
     "react": "^19.1.1",


### PR DESCRIPTION
## Summary
- enforce Node.js v18 or newer via package.json `engines`
- document Node.js >=18 requirement and basic project commands in README

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68967c65a9b8832c86edbe299ce08222