### PR TITLE
chore: adjust Wrangler Pages build settings

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,4 @@
+pages_build_output_dir = "dist"
+
+[build]
+command = "npm run build"


### PR DESCRIPTION
## Summary
- configure `wrangler.toml` for Pages by moving `pages_build_output_dir` to the top level and keeping only the build command under `[build]`

## Testing
- `npm run build`
- `npx wrangler pages dev`


------
https://chatgpt.com/codex/tasks/task_e_6896843c269c832c96521c8b77d3c0c2