### PR TITLE
Handle network errors in loadOffices

### DIFF
--- a/src/utils/dataLoader.js
+++ b/src/utils/dataLoader.js
@@ -1,4 +1,11 @@
 export async function loadOffices() {
-  const res = await fetch('/data/offices.json');
-  return res.json();
+  try {
+    const res = await fetch('/data/offices.json');
+    if (!res.ok) {
+      return [];
+    }
+    return await res.json();
+  } catch (err) {
+    return [];
+  }
 }

--- a/tests/dataLoader.test.js
+++ b/tests/dataLoader.test.js
@@ -5,10 +5,17 @@ test('loadOffices returns parsed JSON', async () => {
   const mockData = [{ id: 1, name: 'Office' }];
   global.fetch = vi.fn(() =>
     Promise.resolve({
+      ok: true,
       json: () => Promise.resolve(mockData),
     })
   );
 
   const data = await loadOffices();
   expect(data).toEqual(mockData);
+});
+
+test('loadOffices returns empty array on fetch failure', async () => {
+  global.fetch = vi.fn(() => Promise.reject(new Error('Network error')));
+  const data = await loadOffices();
+  expect(data).toEqual([]);
 });


### PR DESCRIPTION
## Summary
- make `loadOffices` more robust by returning an empty array when fetching offices fails or returns a non-ok response
- expand data loader tests to cover fetch errors

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68968d6b1eb8832cb59dd0ba54995c80