### PR TITLE
Use base URL for offices data fetch

### DIFF
--- a/src/utils/dataLoader.js
+++ b/src/utils/dataLoader.js
@@ -1,6 +1,7 @@
 export async function loadOffices() {
   try {
-    const res = await fetch('/data/offices.json');
+    const url = `${import.meta.env.BASE_URL}data/offices.json`;
+    const res = await fetch(url);
     if (!res.ok) {
       return [];
     }

--- a/tests/dataLoader.test.js
+++ b/tests/dataLoader.test.js
@@ -14,6 +14,22 @@ test('loadOffices returns parsed JSON', async () => {
   expect(data).toEqual(mockData);
 });
 
+test('loadOffices uses BASE_URL for fetch path', async () => {
+  const fetchMock = vi.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve([]),
+    })
+  );
+  global.fetch = fetchMock;
+
+  await loadOffices();
+
+  expect(fetchMock).toHaveBeenCalledWith(
+    `${import.meta.env.BASE_URL}data/offices.json`
+  );
+});
+
 test('loadOffices returns empty array on fetch failure', async () => {
   global.fetch = vi.fn(() => Promise.reject(new Error('Network error')));
   const data = await loadOffices();


### PR DESCRIPTION
## Summary
- Build the offices JSON fetch URL using `import.meta.env.BASE_URL` so it works under any deployment path
- Test that `loadOffices` requests the file relative to the base URL

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68969256c030832cb6a0b8c8fd5478d0