### PR TITLE
feat: add error boundary

### DIFF
--- a/src/components/ErrorBoundary.jsx
+++ b/src/components/ErrorBoundary.jsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+export default class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError() {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    if (import.meta.env.DEV) {
+      console.error('ErrorBoundary caught an error', error, errorInfo);
+    }
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        <div role="alert" className="p-4 text-center">
+          Something went wrong.
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}
+

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -5,6 +5,7 @@ import './index.css';
 import Home from './pages/Home';
 import Links from './pages/Links';
 import Navbar from './components/Navbar';
+import ErrorBoundary from './components/ErrorBoundary';
 
 function App() {
   return (
@@ -22,4 +23,8 @@ function App() {
   );
 }
 
-ReactDOM.createRoot(document.getElementById('root')).render(<App />);
+ReactDOM.createRoot(document.getElementById('root')).render(
+  <ErrorBoundary>
+    <App />
+  </ErrorBoundary>
+);


### PR DESCRIPTION
## Summary
- add ErrorBoundary component to show fallback message and log errors in development
- wrap App with ErrorBoundary in main entry point

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689692503ccc832cb59bed8ccc80aad2