### PR TITLE
Align color tokens with design palette

### DIFF
--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -9,7 +9,8 @@
   --surface: #101826;
   --text: #E6EDF3;
   --muted: #A9B4C0;
-  --accent: #22A2FF;
+  --brand: #22A2FF;
+  --accent: #1FAD83;
   --border: #1E2A3A;
   color-scheme: dark;
 }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,12 +1,14 @@
 :root {
-  --bg-0: #0b0f14;      /* page background (near-black blue) */
-  --bg-1: #10151c;      /* elevated panels */
+  --bg-0: #0B0F17;      /* page background */
+  --bg-1: #101826;      /* elevated panels */
   --bg-2: #17202a;      /* higher elevation / popovers */
-  --text-1: #e6edf3;    /* primary text */
-  --text-2: #9fb0c0;    /* secondary text */
-  --border-1: #24303d;  /* subtle borders */
-  --brand: #00d0ff;     /* cyan accent */
-  --accent: #7a5cff;    /* purple alt accent */
-  --focus: #77ffe1;     /* focus ring */
-  --ok: #2ecc71; --warn: #f39c12; --err: #e74c3c;
+  --text-1: #E6EDF3;    /* primary text */
+  --text-2: #A9B4C0;    /* secondary text */
+  --border-1: #1E2A3A;  /* keyline/border */
+  --brand: #22A2FF;     /* accent 1 (action) */
+  --accent: #1FAD83;    /* accent 2 (success) */
+  --focus: #22A2FF;     /* focus ring */
+  --ok: #1FAD83;
+  --warn: #FFB020;
+  --err: #FF5A5A;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -17,7 +17,6 @@ export default {
         text: "var(--text)",
         muted: "var(--muted)",
         border: "var(--border)",
-        accent2: "var(--accent)",
         focus: "var(--focus)",
         ok: "var(--ok)",
         warn: "var(--warn)",


### PR DESCRIPTION
## Summary
- update CSS tokens to new background, text, accent, and status colors
- expose revised palette via Tailwind config

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d2efe54b4832c90f1723f01bdb298