### PR TITLE
Align color tokens with design palette

### DIFF
--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,3 +1,4 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
 @import "./tokens.css";
 
 @tailwind base;
@@ -5,18 +6,18 @@
 @tailwind utilities;
 
 :root {
-  --bg: #0B0F17;
-  --surface: #101826;
-  --text: #E6EDF3;
-  --muted: #A9B4C0;
-  --accent: #22A2FF;
-  --border: #1E2A3A;
   color-scheme: dark;
+  font-family: 'Inter', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+}
+
+code, pre {
+  font-family: 'JetBrains Mono', monospace;
 }
 
 html, body, #root { height: 100%; background: var(--bg-0); color: var(--text-1); }
 * { box-sizing: border-box; }
 a { color: var(--brand); }
+.hover\:brighten:hover { filter: brightness(1.02); }
 .focus-ring:focus-visible { outline: 2px solid var(--focus); outline-offset: 2px; }
 /* Fluid type */
 :root { --step-0: clamp(14px, 1.2vw, 16px); --step-1: clamp(18px, 1.6vw, 20px); }

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -1,12 +1,14 @@
 :root {
-  --bg-0: #0b0f14;      /* page background (near-black blue) */
-  --bg-1: #10151c;      /* elevated panels */
+  --bg-0: #0B0F17;      /* page background */
+  --bg-1: #101826;      /* elevated panels */
   --bg-2: #17202a;      /* higher elevation / popovers */
-  --text-1: #e6edf3;    /* primary text */
-  --text-2: #9fb0c0;    /* secondary text */
-  --border-1: #24303d;  /* subtle borders */
-  --brand: #00d0ff;     /* cyan accent */
-  --accent: #7a5cff;    /* purple alt accent */
-  --focus: #77ffe1;     /* focus ring */
-  --ok: #2ecc71; --warn: #f39c12; --err: #e74c3c;
+  --text-1: #E6EDF3;    /* primary text */
+  --text-2: #A9B4C0;    /* secondary text */
+  --border-1: #1E2A3A;  /* keyline/border */
+  --brand: #22A2FF;     /* accent 1 (action) */
+  --accent: #1FAD83;    /* accent 2 (success) */
+  --focus: #22A2FF;     /* focus ring */
+  --ok: #1FAD83;
+  --warn: #FFB020;
+  --err: #FF5A5A;
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -13,15 +13,17 @@ export default {
         b1: "var(--border-1)",
         brand: "var(--brand)",
         accent: "var(--accent)",
-        surface: "var(--surface)",
-        text: "var(--text)",
-        muted: "var(--muted)",
-        border: "var(--border)",
-        accent2: "var(--accent)",
         focus: "var(--focus)",
         ok: "var(--ok)",
         warn: "var(--warn)",
         err: "var(--err)",
+      },
+      fontFamily: {
+        sans: ['Inter', 'system-ui', '-apple-system', 'Segoe UI', 'Roboto', 'sans-serif'],
+        mono: ['JetBrains Mono', 'monospace'],
+      },
+      borderRadius: {
+        DEFAULT: '4px',
       },
       boxShadow: {
         'e1': "0 8px 24px rgba(0,0,0,.35)",


### PR DESCRIPTION
## Summary
- update CSS tokens to new background, text, accent, and status colors
- expose revised palette via Tailwind config
- import Inter and JetBrains Mono fonts and map them in Tailwind
- remove legacy color variables and add hover brighten utility

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_689d2efe54b4832c90f1723f01bdb298