### PR TITLE
feat: add icons to navigation cards

### DIFF
--- a/cisadex/assets/about.svg
+++ b/cisadex/assets/about.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="10" fill="#64748b"/>
+  <path d="M9.5 9a2.5 2.5 0 0 1 5 0c0 2.5-2.5 2-2.5 4" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+  <circle cx="12" cy="17" r="1" fill="#fff"/>
+</svg>

--- a/cisadex/assets/inform.svg
+++ b/cisadex/assets/inform.svg
@@ -1,0 +1,5 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="10" fill="#0ea5e9"/>
+  <line x1="12" y1="8" x2="12" y2="12" stroke="#fff" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="12" cy="16" r="1" fill="#fff"/>
+</svg>

--- a/cisadex/assets/learn.svg
+++ b/cisadex/assets/learn.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="10" fill="#9333ea"/>
+  <path d="M6 8h5v9H6a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2zm12 0h-5v9h5a2 2 0 0 0 2-2V8a2 2 0 0 0-2-2z" fill="none" stroke="#fff" stroke-width="2" stroke-linejoin="round"/>
+</svg>

--- a/cisadex/assets/partner.svg
+++ b/cisadex/assets/partner.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="10" fill="#14b8a6"/>
+  <path d="M8 13l2 2 4-4 2 2" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/cisadex/assets/prepare.svg
+++ b/cisadex/assets/prepare.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="10" fill="#ea580c"/>
+  <path d="M8 13l2 2 4-4" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/cisadex/assets/protect.svg
+++ b/cisadex/assets/protect.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="10" fill="#16a34a"/>
+  <path d="M12 4l6 2v5c0 3.9-2.7 7.2-6 8-3.3-.8-6-4.1-6-8V6l6-2z" fill="none" stroke="#fff" stroke-width="2" stroke-linejoin="round"/>
+</svg>

--- a/cisadex/assets/respond.svg
+++ b/cisadex/assets/respond.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="10" fill="#dc2626"/>
+  <path d="M12 8v4l3 1" stroke="#fff" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>

--- a/cisadex/catalog.html
+++ b/cisadex/catalog.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>CISA Catalog</title>
+  <link rel="icon" href="assets/cisa.svg">
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <header class="app-header">
+    <div class="brand">
+      <img src="assets/cisa.svg" alt="CISA" class="logo" />
+      <h1>CISA Catalog</h1>
+    </div>
+    <input id="search" type="search" placeholder="Search CISA (programs, sectors, SCC/GCC, JCDC, docs)..." aria-label="Search" />
+  </header>
+
+  <nav class="tabs" role="tablist" aria-label="Primary">
+    <button class="tab active" data-panel="respond">Respond</button>
+    <button class="tab" data-panel="prepare">Prepare</button>
+    <button class="tab" data-panel="protect">Protect</button>
+    <button class="tab" data-panel="inform">Inform</button>
+    <button class="tab" data-panel="learn">Learn</button>
+    <button class="tab" data-panel="partner">Partner</button>
+    <button class="tab" data-panel="about">About CISA</button>
+  </nav>
+
+  <main id="content">
+    <section id="respond" class="panel active" tabindex="0" aria-labelledby="tab-respond">
+      <h2>Respond</h2>
+      <p>Incident response, reporting, and on-call resources.</p>
+      <div class="grid" data-category="respond"></div>
+    </section>
+
+    <section id="prepare" class="panel" tabindex="0" aria-labelledby="tab-prepare">
+      <h2>Prepare</h2>
+      <p>Guides, playbooks, exercises, and critical infrastructure resilience.</p>
+      <div class="grid" data-category="prepare"></div>
+    </section>
+
+    <section id="protect" class="panel" tabindex="0" aria-labelledby="tab-protect">
+      <h2>Protect</h2>
+      <p>Cyber hygiene services, vulnerability management, KEV catalog, advisories.</p>
+      <div class="grid" data-category="protect"></div>
+    </section>
+
+    <section id="inform" class="panel" tabindex="0" aria-labelledby="tab-inform">
+      <h2>Inform</h2>
+      <p>Alerts, advisories, blog posts, press releases, ICS/OT advisories.</p>
+      <div class="grid" data-category="inform"></div>
+    </section>
+
+    <section id="learn" class="panel" tabindex="0" aria-labelledby="tab-learn">
+      <h2>Learn</h2>
+      <p>Training courses, awareness materials, and tabletop exercises.</p>
+      <div class="grid" data-category="learn"></div>
+    </section>
+
+    <section id="partner" class="panel" tabindex="0" aria-labelledby="tab-partner">
+      <h2>Partner</h2>
+      <p>JCDC, SCC/GCC, ISACs/ISAOs, and public-private programs.</p>
+      <div class="grid" data-category="partner"></div>
+    </section>
+
+    <section id="about" class="panel" tabindex="0" aria-labelledby="tab-about">
+      <h2>About CISA</h2>
+      <p>What CISA is, how it’s organized, and where to go next.</p>
+      <div class="grid" data-category="about"></div>
+    </section>
+  </main>
+
+  <footer class="app-footer">
+    <span>Built for fast navigation of public CISA content.</span>
+    <span id="status"></span>
+  </footer>
+
+  <template id="card-template">
+    <a class="card" target="_blank" rel="noopener">
+      <div class="card-title"></div>
+      <div class="card-meta"></div>
+    </a>
+  </template>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/cisadex/data/index.json
+++ b/cisadex/data/index.json
@@ -1,6 +1,7 @@
 {
   "items": [
     {
+      "icon": "respond.svg",
       "title": "Report a Cyber Incident",
       "category": "respond",
       "url": "https://www.cisa.gov/report",
@@ -14,6 +15,7 @@
       ]
     },
     {
+      "icon": "respond.svg",
       "title": "Federal Incident Response Playbook",
       "category": "respond",
       "url": "https://www.cisa.gov/resources-tools/resources/federal-incident-response-playbook",
@@ -27,6 +29,7 @@
       ]
     },
     {
+      "icon": "respond.svg",
       "title": "Ransomware Response Checklist",
       "category": "respond",
       "url": "https://www.stopransomware.gov/response",
@@ -39,10 +42,11 @@
       ]
     },
     {
+      "icon": "respond.svg",
       "title": "ICS-CERT Incident Reporting",
       "category": "respond",
       "url": "https://www.cisa.gov/ics",
-      "meta": "Report OT/ICS incidents directly to CISA\u2019s ICS team for assistance.",
+      "meta": "Report OT/ICS incidents directly to CISA’s ICS team for assistance.",
       "tags": [
         "ICS",
         "OT",
@@ -51,6 +55,7 @@
       ]
     },
     {
+      "icon": "prepare.svg",
       "title": "Cybersecurity Performance Goals (CPGs)",
       "category": "prepare",
       "url": "https://www.cisa.gov/cpg",
@@ -67,6 +72,7 @@
       ]
     },
     {
+      "icon": "prepare.svg",
       "title": "CISA Cyber Hygiene Services",
       "category": "prepare",
       "url": "https://www.cisa.gov/cyber-hygiene-services",
@@ -81,6 +87,7 @@
       ]
     },
     {
+      "icon": "prepare.svg",
       "title": "Tabletop Exercise Packages (CTEP)",
       "category": "prepare",
       "url": "https://www.cisa.gov/resources-tools/resources/tabletop-exercises",
@@ -94,6 +101,7 @@
       ]
     },
     {
+      "icon": "prepare.svg",
       "title": "Infrastructure Dependency/Interdependency Planning",
       "category": "prepare",
       "url": "https://www.cisa.gov/resources-tools/resources/dependency-planning",
@@ -108,6 +116,7 @@
       ]
     },
     {
+      "icon": "protect.svg",
       "title": "Known Exploited Vulnerabilities (KEV) Catalog",
       "category": "protect",
       "url": "https://www.cisa.gov/kev",
@@ -121,6 +130,7 @@
       ]
     },
     {
+      "icon": "protect.svg",
       "title": "Shields Up",
       "category": "protect",
       "url": "https://www.cisa.gov/shields-up",
@@ -134,6 +144,7 @@
       ]
     },
     {
+      "icon": "protect.svg",
       "title": "Stop Ransomware Guidance Center",
       "category": "protect",
       "url": "https://www.stopransomware.gov/",
@@ -147,6 +158,7 @@
       ]
     },
     {
+      "icon": "protect.svg",
       "title": "Secure by Design / Default Principles",
       "category": "protect",
       "url": "https://www.cisa.gov/securebydesign",
@@ -160,6 +172,7 @@
       ]
     },
     {
+      "icon": "inform.svg",
       "title": "CISA Alerts & Joint Cybersecurity Advisories",
       "category": "inform",
       "url": "https://www.cisa.gov/news-events/cybersecurity-advisories",
@@ -172,6 +185,7 @@
       ]
     },
     {
+      "icon": "inform.svg",
       "title": "ICS Advisories (ICSA)",
       "category": "inform",
       "url": "https://www.cisa.gov/ics/advisories",
@@ -185,6 +199,7 @@
       ]
     },
     {
+      "icon": "inform.svg",
       "title": "Top Routinely Exploited Vulnerabilities",
       "category": "inform",
       "url": "https://www.cisa.gov/resources-tools/reports/routinely-exploited-vulnerabilities",
@@ -198,6 +213,7 @@
       ]
     },
     {
+      "icon": "inform.svg",
       "title": "Emergency Directives & Binding Operational Directives",
       "category": "inform",
       "url": "https://www.cisa.gov/directives",
@@ -212,6 +228,7 @@
       ]
     },
     {
+      "icon": "learn.svg",
       "title": "CISA Training & Exercises Catalog",
       "category": "learn",
       "url": "https://www.cisa.gov/training-exercises",
@@ -227,6 +244,7 @@
       ]
     },
     {
+      "icon": "learn.svg",
       "title": "ICS Security Training (INL/ICS-Range programs linkouts)",
       "category": "learn",
       "url": "https://www.cisa.gov/ics/training",
@@ -241,6 +259,7 @@
       ]
     },
     {
+      "icon": "learn.svg",
       "title": "Phishing & Social Engineering Awareness",
       "category": "learn",
       "url": "https://www.cisa.gov/resources-tools/resources/phishing-awareness",
@@ -253,6 +272,7 @@
       ]
     },
     {
+      "icon": "learn.svg",
       "title": "Incident Response Tabletop Library",
       "category": "learn",
       "url": "https://www.cisa.gov/resources-tools/resources/incident-response-tabletops",
@@ -266,6 +286,7 @@
       ]
     },
     {
+      "icon": "partner.svg",
       "title": "Join the Joint Cyber Defense Collaborative (JCDC)",
       "category": "partner",
       "url": "https://www.cisa.gov/jcdc",
@@ -279,6 +300,7 @@
       ]
     },
     {
+      "icon": "partner.svg",
       "title": "Sector Councils (SCC/GCC) Overview",
       "category": "partner",
       "url": "https://www.cisa.gov/partner-councils",
@@ -291,6 +313,7 @@
       ]
     },
     {
+      "icon": "partner.svg",
       "title": "Information Sharing Programs (AIS/MS-ISAC/E-ISAC linkouts)",
       "category": "partner",
       "url": "https://www.cisa.gov/information-sharing",
@@ -305,6 +328,7 @@
       ]
     },
     {
+      "icon": "about.svg",
       "title": "About CISA",
       "category": "about",
       "url": "https://www.cisa.gov/about",
@@ -316,6 +340,7 @@
       ]
     },
     {
+      "icon": "about.svg",
       "title": "Critical Infrastructure Sectors & SRMAs",
       "category": "about",
       "url": "https://www.cisa.gov/topics/critical-infrastructure-security-and-resilience/critical-infrastructure-sectors",
@@ -327,6 +352,7 @@
       ]
     },
     {
+      "icon": "about.svg",
       "title": "Publications & Guidance Library",
       "category": "about",
       "url": "https://www.cisa.gov/resources-tools",

--- a/cisadex/script.js
+++ b/cisadex/script.js
@@ -30,6 +30,13 @@ async function load(){
 function makeCard(item){
   const node = tpl.content.firstElementChild.cloneNode(true);
   node.href = item.url;
+  if(item.icon){
+    const img = document.createElement('img');
+    img.src = `assets/${item.icon}`;
+    img.alt = '';
+    img.className = 'card-icon';
+    node.appendChild(img);
+  }
   node.querySelector('.card-title').textContent = item.title;
   node.querySelector('.card-meta').textContent = item.meta ?? item.category;
   return node;

--- a/cisadex/style.css
+++ b/cisadex/style.css
@@ -71,6 +71,7 @@ h1{font-size:1.2rem; margin:0; letter-spacing:.3px}
 }
 .card{
   display:block;
+  position:relative;
   background:linear-gradient(180deg, #111a2d, #0d1526);
   border:1px solid var(--border);
   border-radius:14px;
@@ -82,6 +83,13 @@ h1{font-size:1.2rem; margin:0; letter-spacing:.3px}
 .card:hover{border-color:var(--accent)}
 .card-title{font-weight:600; margin-bottom:.25rem}
 .card-meta{color:var(--muted); font-size:.92rem}
+.card-icon{
+  position:absolute;
+  top:1rem;
+  right:1rem;
+  width:32px;
+  height:32px;
+}
 .app-footer{
   padding:1rem clamp(1rem, 3vw, 2rem);
   border-top:1px solid var(--border);


### PR DESCRIPTION
## Summary
- add simple SVG icons for each category
- reference icons in data entries
- render optional card icons and style them
- add catalog page hosting the tabbed sections

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895dc6b7548832c9595453fe3998347