### PR TITLE
Feat: integrate multiple entity types with info cards

### DIFF
--- a/public/data/agencies.json
+++ b/public/data/agencies.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "a1",
+    "name": "Cybersecurity and Infrastructure Security Agency",
+    "lat": 38.8951,
+    "lng": -77.0364,
+    "website": "https://www.cisa.gov"
+  },
+  {
+    "id": "a2",
+    "name": "Federal Bureau of Investigation",
+    "lat": 38.8977,
+    "lng": -77.0365,
+    "website": "https://www.fbi.gov"
+  }
+]

--- a/public/data/isacs.json
+++ b/public/data/isacs.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "i1",
+    "name": "Financial Services ISAC",
+    "lat": 38.905,
+    "lng": -77.042,
+    "website": "https://www.fsisac.com"
+  },
+  {
+    "id": "i2",
+    "name": "Electricity ISAC",
+    "lat": 38.8895,
+    "lng": -77.0353,
+    "website": "https://www.eisac.com"
+  }
+]

--- a/public/data/labs.json
+++ b/public/data/labs.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "l1",
+    "name": "Sandia National Laboratories",
+    "lat": 35.0522,
+    "lng": -106.541,
+    "website": "https://www.sandia.gov"
+  },
+  {
+    "id": "l2",
+    "name": "Los Alamos National Laboratory",
+    "lat": 35.844,
+    "lng": -106.287,
+    "website": "https://www.lanl.gov"
+  }
+]

--- a/src/components/MapView.jsx
+++ b/src/components/MapView.jsx
@@ -2,11 +2,15 @@ import { useEffect, useRef } from "react";
 import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 
+function isValidCoord(d) {
+  const lon = Number(d?.lon ?? d?.lng), lat = Number(d?.lat);
+  return Number.isFinite(lon) && Number.isFinite(lat) && lon >= -180 && lon <= 180 && lat >= -90 && lat <= 90;
+}
+
 async function waitForStyle(map) {
   if (map.isStyleLoaded?.()) return;
   await new Promise((resolve) => {
     const onIdle = () => { map.off("idle", onIdle); resolve(); };
-    // 'load' fires once; 'idle' ensures all style resources are ready
     map.once("load", () => map.once("idle", onIdle));
   });
 }
@@ -15,82 +19,109 @@ export default function MapView({ data = [], loading = false }) {
   const containerRef = useRef(null);
   const mapRef = useRef(null);
 
-  // 1) Create/remove map
+  // Debug: see what arrives
+  useEffect(() => {
+    console.log("[MapView] data length:", Array.isArray(data) ? data.length : "n/a", data?.slice?.(0,3));
+  }, [data]);
+
+  // Create map once
   useEffect(() => {
     if (!containerRef.current) return;
     const map = new maplibregl.Map({
       container: containerRef.current,
       style: "https://demotiles.maplibre.org/style.json",
       center: [-98.5795, 39.8283],
-      zoom: 3,
+      zoom: 3
     });
     mapRef.current = map;
-
     return () => { try { map.remove(); } catch {} mapRef.current = null; };
   }, []);
 
-  // 2) Add or update data AFTER style is ready
+  // Add/update source+layer after style ready
   useEffect(() => {
     const map = mapRef.current;
     if (!map || loading) return;
 
+    const srcId = "offices";
+    const layerId = "offices-circles";
+    let clickHandler;
     let cancelled = false;
+
     (async () => {
       try {
         await waitForStyle(map);
         if (cancelled) return;
 
-        // Ensure source exists or (re)create it
-        const srcId = "offices";
+        const features = (Array.isArray(data) ? data : []).filter(isValidCoord).map(d => ({
+          type: "Feature",
+          geometry: { type: "Point", coordinates: [Number(d.lon ?? d.lng), Number(d.lat)] },
+          properties: d
+        }));
+        const geojson = { type: "FeatureCollection", features };
+
         const existing = map.getSource?.(srcId);
-        const geojson = {
-          type: "FeatureCollection",
-          features: (data || []).map((d) => ({
-            type: "Feature",
-            geometry: { type: "Point", coordinates: [d.lon, d.lat] },
-            properties: d,
-          })),
-        };
-
         if (!existing) {
-          // First time: add source + layers
           map.addSource(srcId, { type: "geojson", data: geojson });
-
-          // Circle layer example
-          if (!map.getLayer("offices-circles")) {
+          if (!map.getLayer(layerId)) {
             map.addLayer({
-              id: "offices-circles",
+              id: layerId,
               type: "circle",
               source: srcId,
               paint: {
-                "circle-radius": 5,
-                "circle-color": "#0ea5e9",
-                "circle-opacity": 0.8,
-              },
+                "circle-radius": 6,
+                "circle-color": [
+                  "match",
+                  ["get", "entity"],
+                  "agency", "#1f78b4",
+                  "field_office", "#33a02c",
+                  "lab", "#e31a1c",
+                  "isac", "#ff7f00",
+                  "#ff0000"
+                ],
+                "circle-opacity": 0.9,
+                "circle-stroke-color": "#111",
+                "circle-stroke-width": 1
+              }
             });
           }
         } else {
-          // Subsequent updates: just set data
           existing.setData(geojson);
         }
 
-        // Fit bounds (only after style load & when we have points)
-        if (geojson.features.length > 0) {
-          const lons = geojson.features.map(f => f.geometry.coordinates[0]);
-          const lats = geojson.features.map(f => f.geometry.coordinates[1]);
+        clickHandler = (e) => {
+          const feature = e.features?.[0];
+          if (!feature) return;
+          const props = feature.properties || {};
+          const title = props.name || props.office_name || "";
+          const desc = props.entity || "";
+          const html = `<div><h3>${title}</h3><p>${desc}</p></div>`;
+          new maplibregl.Popup({ closeButton: true })
+            .setLngLat(e.lngLat)
+            .setHTML(html)
+            .addTo(map);
+        };
+        map.on("click", layerId, clickHandler);
+
+        // Fit bounds only when we have points
+        if (features.length > 0) {
+          const lons = features.map(f => f.geometry.coordinates[0]);
+          const lats = features.map(f => f.geometry.coordinates[1]);
           const west = Math.min(...lons), east = Math.max(...lons);
           const south = Math.min(...lats), north = Math.max(...lats);
-          if (isFinite(west) && isFinite(east) && isFinite(south) && isFinite(north)) {
+          if (Number.isFinite(west) && Number.isFinite(east) && Number.isFinite(south) && Number.isFinite(north)) {
             map.fitBounds([[west, south], [east, north]], { padding: 32, maxZoom: 10, duration: 0 });
           }
         }
       } catch (e) {
-        console.error("Map data/update failed:", e);
-        // Don’t rethrow; we’ve handled it so the app doesn’t white-screen
+        console.error("[MapView] update failed:", e);
+        // swallow to avoid ErrorBoundary crash
       }
     })();
 
-    return () => { cancelled = true; };
+    return () => {
+      cancelled = true;
+      if (clickHandler) map.off("click", layerId, clickHandler);
+    };
   }, [data, loading]);
 
   return (

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,33 +3,34 @@ import MapView from '../components/MapView';
 import FilterPanel from '../components/FilterPanel';
 // RssFeedPanel now fetches RSS feeds via a server-side function
 // import RssFeedPanel from '../components/RssFeedPanel';
-import { loadOffices } from '../utils/dataLoader';
+import { loadEntities } from '../utils/dataLoader';
 
 export default function Home() {
-  const [offices, setOffices] = useState([]);
+  const [entities, setEntities] = useState([]);
+  // Defaults: show everything until user picks something
   const [filters, setFilters] = useState({ agency: [], role_type: [] });
   const [loading, setLoading] = useState(true);
   const [showFilters, setShowFilters] = useState(false);
 
   useEffect(() => {
-    loadOffices().then((data) => {
-      setOffices(data);
+    loadEntities().then((data) => {
+      setEntities(data);
       setLoading(false);
     });
   }, []);
 
-  const agencies = useMemo(() => [...new Set(offices.map((o) => o.agency))], [offices]);
-  const roles = useMemo(() => [...new Set(offices.map((o) => o.role_type))], [offices]);
+  const agencies = useMemo(() => [...new Set(entities.map(o => o.agency).filter(Boolean))], [entities]);
+  const roles = useMemo(() => [...new Set(entities.map(o => o.role_type).filter(Boolean))], [entities]);
 
-  const filteredData = useMemo(
-    () =>
-      offices.filter(
-        (o) =>
-          (filters.agency.length === 0 || filters.agency.includes(o.agency)) &&
-          (filters.role_type.length === 0 || filters.role_type.includes(o.role_type))
-      ),
-    [offices, filters]
-  );
+  const filteredData = useMemo(() => {
+    const agencyActive = filters.agency.length > 0;
+    const roleActive = filters.role_type.length > 0;
+    return entities.filter(o => {
+      const okAgency = !agencyActive || !o.agency || filters.agency.includes(o.agency);
+      const okRole = !roleActive || !o.role_type || filters.role_type.includes(o.role_type);
+      return okAgency && okRole;
+    });
+  }, [entities, filters]);
 
   if (loading) {
     return <div className="flex items-center justify-center h-full">Loading map...</div>;

--- a/src/utils/dataLoader.js
+++ b/src/utils/dataLoader.js
@@ -1,12 +1,40 @@
-export async function loadOffices() {
+async function loadJson(name) {
   try {
-    const url = `${import.meta.env.BASE_URL}data/offices.json`;
+    const url = `${import.meta.env.BASE_URL}data/${name}.json`;
     const res = await fetch(url);
-    if (!res.ok) {
-      return [];
-    }
+    if (!res.ok) return [];
     return await res.json();
-  } catch (err) {
+  } catch {
     return [];
   }
+}
+
+export async function loadOffices() {
+  return loadJson('offices');
+}
+
+export async function loadEntities() {
+  const [offices, agencies, labs, isacs] = await Promise.all([
+    loadJson('offices'),
+    loadJson('agencies'),
+    loadJson('labs'),
+    loadJson('isacs')
+  ]);
+
+  function normalize(arr, entity) {
+    return arr.map((d) => ({
+      ...d,
+      entity,
+      name: d.name ?? d.office_name,
+      lon: Number(d.lon ?? d.lng),
+      lat: Number(d.lat)
+    }));
+  }
+
+  return [
+    ...normalize(offices, 'field_office'),
+    ...normalize(agencies, 'agency'),
+    ...normalize(labs, 'lab'),
+    ...normalize(isacs, 'isac')
+  ];
 }


### PR DESCRIPTION
## Summary
- load agencies, labs, and ISAC datasets alongside field offices
- show all entities on the map with type-based colors and popups
- keep unmatched entities visible when agency or role filters are applied

## Testing
- `npm ci`
- `npm run dev`
- `npm run build`
- `npm run preview`
- `curl -I http://localhost:4176`


------
https://chatgpt.com/codex/tasks/task_e_6896a3a73380832c9cc64c322fe071de