### PR TITLE
Fix splash video relative path

### DIFF
--- a/public/splash.html
+++ b/public/splash.html
@@ -37,7 +37,7 @@
       <!-- If using repo asset, keep this: -->
       <video id="bgvid" muted playsinline autoplay loop preload="metadata"
              poster="data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==">
-        <source src="/assets/cisadex-splash.mp4" type="video/mp4">
+        <source src="assets/cisadex-splash.mp4" type="video/mp4">
         <!-- If using CDN instead, replace with:
         <source src="https://cdn.yourdomain.com/cisadex-splash.mp4" type="video/mp4">
         -->


### PR DESCRIPTION
## Summary
- reference splash video with relative path so it loads without a leading slash

## Testing
- `npm test`
- `npm run build`
- `npm run deploy` *(fails: wrangler not found)*
- `npm run preview` followed by curl to splash video

------
https://chatgpt.com/codex/tasks/task_e_689dbb036690832c8533d76eb2874115